### PR TITLE
Make rails 4 scope compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ rvm:
   - 2.1.10
   - 2.2.5
 script: bundle exec rake spec
-# Rails is not supported on Ruby 2.1.x
+# Rails 5 is not supported on Ruby 2.1.x
 matrix:
   exclude:
     - rvm: 2.1.10

--- a/lib/m2m_fast_insert/has_and_belongs_to_many_override.rb
+++ b/lib/m2m_fast_insert/has_and_belongs_to_many_override.rb
@@ -3,10 +3,11 @@ module M2MFastInsert
     # Decorate the original habtm to call our method definition
     #
     # name - Plural name of the model we're associating with
-    # options - see ActiveRecord docs
-    def has_and_belongs_to_many(name, options = {})
+    # options - see ActiveRecord docs. Rails 4+ allows an optional proc in addition to the params
+    def has_and_belongs_to_many(name, *options)
       super
-      define_fast_methods_for_model(name, options)
+      m2m_options = options.last.is_a?(Hash) ? options.last : {}
+      define_fast_methods_for_model(name, m2m_options)
     end
 
     private

--- a/spec/support/test_model.rb
+++ b/spec/support/test_model.rb
@@ -24,6 +24,9 @@ end
 
 class User < ActiveRecord::Base
   has_and_belongs_to_many :posts
+  if Rails::VERSION::MAJOR >= 4
+    has_and_belongs_to_many :posts_without_content, -> { where(content: nil) }, class_name: 'Post'
+  end
   has_many :connections
   has_many :friends, :through => :connections
 end

--- a/spec/support/test_model.rb
+++ b/spec/support/test_model.rb
@@ -24,7 +24,7 @@ end
 
 class User < ActiveRecord::Base
   has_and_belongs_to_many :posts
-  if Rails::VERSION::MAJOR >= 4
+  if ::Rails::VERSION::MAJOR >= 4
     has_and_belongs_to_many :posts_without_content, -> { where(content: nil) }, class_name: 'Post'
   end
   has_many :connections

--- a/spec/support/test_model.rb
+++ b/spec/support/test_model.rb
@@ -24,7 +24,7 @@ end
 
 class User < ActiveRecord::Base
   has_and_belongs_to_many :posts
-  if ::Rails::VERSION::MAJOR >= 4
+  if ActiveRecord::VERSION::MAJOR >= 4
     has_and_belongs_to_many :posts_without_content, -> { where(content: nil) }, class_name: 'Post'
   end
   has_many :connections


### PR DESCRIPTION
HABTM in rails 4 allows for a proc/lambda to be passed along with options.
The current method signature doesn't allow the proc and params.